### PR TITLE
Add GitHub link to author social profiles

### DIFF
--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -34,6 +34,8 @@ profiles:
     url: https://twitter.com/waldo_tk
   - icon: brands/linkedin
     url: https://www.linkedin.com/in/waldo-ojeda/
+  - icon: brands/github
+    url: https://github.com/tekampa
 
 interests:
   - Household Finance


### PR DESCRIPTION
## Summary
- Add a GitHub button to the author's social links, linking to https://github.com/tekampa

## Verification
- Built the site with the project-pinned Hugo 0.136.5 (via asdf) — build succeeds
- Confirmed the rendered `index.html` includes a proper GitHub anchor with the brands/github SVG icon:
  `<a href=https://github.com/tekampa target=_blank rel=noopener aria-label=brands/github>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)