### PR TITLE
docs: add CLAUDE.md and fix stale menus comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+Guidance for working in this repository.
+
+## What this is
+
+Source for [waldotekampa.me](https://waldotekampa.me/) — the personal academic
+site of Waldo Ojeda. It is a static [Hugo](https://gohugo.io/) site built on the
+[Hugo Blox](https://hugoblox.com/) `blox-tailwind` module (academic-cv starter).
+There is no application code; everything is content (Markdown) and configuration
+(YAML).
+
+## Toolchain
+
+- **Hugo Extended 0.136.5** — pinned in three places that must stay in sync:
+  `.tool-versions`, `hugoblox.yaml`, and `.github/workflows/publish.yaml`
+  (`HUGO_VERSION`). Change all three together.
+- **Go 1.19+** — Hugo Modules pull the theme; see `go.mod` / `go.sum`.
+- **asdf** — recommended for matching the pinned Hugo version locally. A plain
+  `asdf install` will not fetch Hugo until the plugin is added.
+
+## Common commands
+
+```bash
+# One-time setup
+asdf plugin add hugo
+asdf install hugo extended_0.136.5
+go mod download
+
+# Local dev server (http://localhost:1313)
+asdf exec hugo server
+
+# Production build (output in public/, which is gitignored)
+asdf exec hugo --gc --minify
+```
+
+## Layout
+
+- `content/_index.md` — homepage; an ordered list of Hugo Blox blocks. Each
+  block has an `id` that the nav links to via `/#<id>`.
+- `content/authors/admin/_index.md` — profile: bio, interests, education,
+  social links, avatar (`avatar.jpg`).
+- `content/post/` — blog posts.
+- `config/_default/` — site config:
+  - `hugo.yaml` — core Hugo settings (baseURL, outputs, markup, taxonomies).
+  - `params.yaml` — appearance, SEO, header/footer, features.
+  - `menus.yaml` — top navigation. Link names map to homepage block `id`s.
+  - `module.yaml` — Hugo Module imports and mounts (the theme).
+  - `languages.yaml` — language setup (English only).
+- `assets/css/` — custom Columbia-themed styling (`custom.css`, `themes/`).
+- `static/uploads/` — current CV and paper PDFs.
+- `static/files/` — compatibility copies so links from the previous (Academic
+  theme) site still resolve. Do not delete without checking inbound links.
+
+## Editing conventions
+
+- **Nav and homepage stay in sync.** When you add, remove, or rename a homepage
+  block in `content/_index.md`, update the matching entry in
+  `config/_default/menus.yaml` (the URL is `/#<block-id>`). Current IDs: `about`,
+  `workingpapers`, `worksinprogress`, `teaching`, `posts`, `contact`.
+- **Use root-relative paths** for links and PDFs (e.g. `/uploads/cv.pdf`). The
+  production base URL is the custom domain; relative-to-root keeps links correct
+  there and avoids the GitHub Pages project-path staging URL.
+- This is content, not code — there are no tests. Verify changes by running
+  `hugo server` and viewing the affected page.
+
+## Deployment
+
+Pushing to `master` triggers `.github/workflows/publish.yaml`, which builds with
+Hugo and deploys to GitHub Pages (Pages **Source** is set to **GitHub Actions**).
+Manual deploys: **Actions** tab → **Deploy website to GitHub Pages** →
+**Run workflow** on `master`.
+
+The custom domain is configured in GitHub Pages settings; this repo
+intentionally has **no `CNAME` file**. `public/` is gitignored — CI builds from
+source.
+
+See `README.md` for the developer-facing summary and `MIGRATION.md` for the
+historical record of the Academic-theme → Hugo Blox cutover.

--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -1,7 +1,7 @@
 # Navigation Links
-#   To link a homepage widget, specify the URL as a hash `#` followed by the filename of the
-  #     desired widget in your `content/home/` folder.
-  #   The weight parameter defines the order that the links will appear in.
+#   To link a homepage section, set the URL to a hash `#` followed by the `id` of
+#     the desired block in `content/_index.md`.
+#   The weight parameter defines the order that the links will appear in.
 
 main:
   - name: Home


### PR DESCRIPTION
## Summary

- Add a `CLAUDE.md` documenting the repository for future work: it describes the site as a static Hugo Blox academic site (no app code), the Hugo 0.136.5 version pin that must stay in sync across `.tool-versions`, `hugoblox.yaml`, and the deploy workflow, the setup/dev/build commands, directory layout, editing conventions (keep nav in sync with homepage block IDs, use root-relative paths), and the GitHub Pages deployment flow.
- Fix a stale comment in `config/_default/menus.yaml` that referenced the obsolete Academic-theme `content/home/` widget folder; it now describes linking to block `id`s in `content/_index.md`.

## Notes

Reviewed `README.md` and `MIGRATION.md` for outdated content — both are accurate and current (versions match across config files, nav links match homepage section IDs), so they were left unchanged. `MIGRATION.md` is kept as a completed historical record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)