### PR TITLE
chore: update Hugo to 0.163.2 (local toolchain → Homebrew)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 name: Deploy website to GitHub Pages
 
 env:
-  HUGO_VERSION: '0.136.5'
+  HUGO_VERSION: '0.163.2'
 
 on:
   # Deploy production changes from the repository's default branch

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ resources/_gen/
 .DS_Store
 hugo_stats.json
 /themes/
+assets/jsconfig.json

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-hugo extended_0.136.5

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,7 +5,7 @@ Hugo Blox source prepared in `website_temp`.
 
 ## Current Structure
 
-- Hugo Extended 0.136.5
+- Hugo Extended 0.163.2
 - Hugo Blox Tailwind module
 - Homepage content in `content/_index.md`
 - Profile data in `content/authors/admin/_index.md`
@@ -93,13 +93,12 @@ stable for several days.
 ## Verification
 
 ```bash
-asdf plugin add hugo
-asdf install hugo extended_0.136.5
+brew install hugo   # Hugo Extended; recent macOS releases are .pkg-only
 go mod download
-asdf exec hugo --gc --minify
+hugo --gc --minify
 ```
 
-The local Hugo version should match `.tool-versions` and the GitHub Actions
-workflow: Hugo Extended 0.136.5.
+The local Hugo version should match the GitHub Actions workflow
+(`HUGO_VERSION` in `.github/workflows/publish.yaml`): Hugo Extended 0.163.2.
 
 The deployment workflow runs when changes are pushed to `master`.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,36 @@
 # Waldo Ojeda Website
 
 Source for [waldotekampa.me](https://waldotekampa.me/), built with Hugo
-0.136.5 and Hugo Blox.
+0.163.2 and Hugo Blox.
 
 ## Local Development
 
-Install Go and [asdf](https://asdf-vm.com/), then install the Hugo plugin and
-the pinned Hugo Extended version used by GitHub Actions. A plain `asdf install`
-will not install Hugo until the plugin is available, and `hugo latest` may not
-match the deployment version.
+Install Go and Hugo Extended. On macOS, Hugo ships only a `.pkg` installer for
+recent releases, so install it with [Homebrew](https://brew.sh/) to match the
+version used by GitHub Actions:
 
 ```bash
-asdf plugin add hugo
-asdf install hugo extended_0.136.5
+brew install hugo   # or: brew upgrade hugo
 go mod download
+```
+
+Confirm the version matches the deployment version (`HUGO_VERSION` in
+`.github/workflows/publish.yaml`):
+
+```bash
+hugo version   # expect: hugo v0.163.2+extended ...
 ```
 
 Start the local development server:
 
 ```bash
-asdf exec hugo server
+hugo server
 ```
 
 Create a production build:
 
 ```bash
-asdf exec hugo --gc --minify
+hugo --gc --minify
 ```
 
 The generated `public/` directory is ignored because GitHub Actions builds the

--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -4,13 +4,13 @@
 
 # Default language
 en:
-  languageCode: en-us
+  locale: en-us
   # Uncomment for multi-lingual sites, and move English content into `en` sub-folder.
   #contentDir: content/en
 
 # Uncomment the lines below to configure your website in a second language.
 #zh:
-#  languageCode: zh-Hans
+#  locale: zh-Hans
 #  contentDir: content/zh
 #  title: Chinese website title...
 #  params:

--- a/hugoblox.yaml
+++ b/hugoblox.yaml
@@ -1,2 +1,2 @@
 build:
-  hugo_version: '0.136.5'
+  hugo_version: '0.163.2'


### PR DESCRIPTION
## Summary
Updates Hugo from the old pinned **0.136.5** to the latest **0.163.2**, and moves local installs from asdf to Homebrew. The `blox-tailwind` theme stays at **v0.3.1** (no Node/Tailwind toolchain added).

## Changes
- **Hugo 0.136.5 → 0.163.2** in `.github/workflows/publish.yaml` (`HUGO_VERSION`) and `hugoblox.yaml`
- **Drop the asdf pin** (`.tool-versions`): recent Hugo releases ship macOS only as a `.pkg`, which the asdf-hugo plugin can't install. Local installs now use Homebrew (`brew install hugo`), documented in `README.md` and `MIGRATION.md`
- **`languageCode` → `locale`** in `config/_default/languages.yaml` (key deprecated in Hugo 0.158.0). Verified rendered `<html lang>`, `og:locale`, and RSS `<language>` are unchanged (`en-us`)
- **Gitignore** the Hugo-generated `assets/jsconfig.json`

## Verification
- Clean production build on Hugo 0.163.2 + theme v0.3.1 (exit 0, 9 pages)
- `hugo server` runs locally and serves HTTP 200; GitHub social link, sitemap, and RSS all render correctly
- CI is unaffected: GitHub Actions runs on Linux, where Hugo still publishes tarballs (`peaceiris/actions-hugo` installs 0.163.2 fine)

## Notes / follow-up
Remaining build warnings are **theme-internal** deprecations (`.Site.Data`, `.Site.AllPages`, `.Site.LanguageCode`, sitemap render hook) from `blox-tailwind` v0.3.1 — non-fatal today. Decoupling from the upstream academic Hugo Blox template (so version-to-version breakage stops affecting us) is being planned as separate follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)