### PR TITLE
docs: align CLAUDE.md with Hugo 0.163.2 / Homebrew toolchain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,26 +12,26 @@ There is no application code; everything is content (Markdown) and configuration
 
 ## Toolchain
 
-- **Hugo Extended 0.136.5** — pinned in three places that must stay in sync:
-  `.tool-versions`, `hugoblox.yaml`, and `.github/workflows/publish.yaml`
-  (`HUGO_VERSION`). Change all three together.
+- **Hugo Extended 0.163.2** — pinned in two places that must stay in sync:
+  `hugoblox.yaml` and `.github/workflows/publish.yaml` (`HUGO_VERSION`).
+  Change both together.
 - **Go 1.19+** — Hugo Modules pull the theme; see `go.mod` / `go.sum`.
-- **asdf** — recommended for matching the pinned Hugo version locally. A plain
-  `asdf install` will not fetch Hugo until the plugin is added.
+- **Homebrew** — used for local installs. Recent Hugo releases ship macOS only
+  as a `.pkg`, so install the matching Extended build with `brew install hugo`
+  (`brew upgrade hugo` to update) and confirm with `hugo version`.
 
 ## Common commands
 
 ```bash
 # One-time setup
-asdf plugin add hugo
-asdf install hugo extended_0.136.5
+brew install hugo   # Hugo Extended; brew upgrade hugo to update
 go mod download
 
 # Local dev server (http://localhost:1313)
-asdf exec hugo server
+hugo server
 
 # Production build (output in public/, which is gitignored)
-asdf exec hugo --gc --minify
+hugo --gc --minify
 ```
 
 ## Layout


### PR DESCRIPTION
## Summary
Updates `CLAUDE.md` to match the toolchain change in #6. It was the only doc still describing the old setup (Hugo 0.136.5 pinned in *three* places, asdf for local installs).

## Changes
- Hugo **0.136.5 → 0.163.2**; pinned in **two** places now (`hugoblox.yaml`, `.github/workflows/publish.yaml`) — `.tool-versions` was removed in #6
- Local install guidance **asdf → Homebrew** (recent Hugo macOS releases are `.pkg`-only)
- Common-commands block updated to plain `hugo` / `brew install hugo`

## Notes
- Touches only `CLAUDE.md`; no overlap with #6, so the two merge in any order. Merging #6 first keeps README/MIGRATION/CLAUDE consistent.
- `README.md` and `MIGRATION.md` are already updated for the same change in #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)